### PR TITLE
Fixed compile issue and added ESP32-S3 support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,3 +24,19 @@ lib_deps =
 	https://github.com/ESP32Async/ESPAsyncWebServer
     bblanchon/ArduinoJson@^7.1.0
 	h2zero/NimBLE-Arduino@^1.4.2
+
+[env:esp32-s3-supermini]
+platform = espressif32
+board = esp32-s3-devkitc-1
+build_flags = -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_ESP32S3_DEV=1 -DCORE_DEBUG_LEVEL=0 -DCONFIG_ESPTOOLPY_FLASHSIZE_4MB
+framework = arduino
+board_build.filesystem = littlefs
+board_build.partitions = partitions.csv
+board_build.flash_size = 4MB
+board_upload.flash_size = 4MB
+monitor_speed = 115200
+lib_deps = 
+	https://github.com/ESP32Async/AsyncTCP
+	https://github.com/ESP32Async/ESPAsyncWebServer
+    bblanchon/ArduinoJson@^7.1.0
+	h2zero/NimBLE-Arduino@^1.4.2

--- a/src/web_config.cpp
+++ b/src/web_config.cpp
@@ -2,6 +2,7 @@
 #include "updater.h"
 #include "config.h"
 #include "logger.h"
+#include <WiFi.h>
 
 #include "static/static_html.h"
 #include "static/static_js.h"


### PR DESCRIPTION
From the current source the compilation was failing due to missing include in web_config.cpp, added include <WiFi.h> to fix that issue.

I found that there are a number of freely available ESP32-S3 super mini boards available and I've used them for a number of other projects so added support for the device in the platformio.ini file. It's similar to the C3 but all the ones I have are limited to 4MB of flash so I've enforced those settings in the s3 device definition.

The s3 device also has the hard coded upload_port and monitor_port - I don't think they should be set in the c3 definition either but have left them to avoid merge conflicts. 